### PR TITLE
Remove redundant package imports

### DIFF
--- a/elsarticle-template-num.tex
+++ b/elsarticle-template-num.tex
@@ -45,7 +45,7 @@
 %% The amssymb package provides various useful mathematical symbols
 \usepackage{amssymb}
 \usepackage{amsmath}
-\usepackage{float} 
+\usepackage{float}
 %\usepackage{url}
 %\usepackage{hyperref}
 
@@ -58,10 +58,8 @@
 %\usepackage{graphicx}
 \usepackage[figurename=Fig.,labelfont=bf,labelsep=period]{caption}
 \usepackage{subcaption}
-\usepackage{amsmath}
 \usepackage{lineno}
 \usepackage{natbib}
-\usepackage{amsmath}
 %\usepackage{gensymb}
 \usepackage{listings}
 \usepackage[ruled,vlined]{algorithm2e}
@@ -72,9 +70,6 @@
 \usepackage{tabularx}   % smart column wrapping to avoid scaling
 \usepackage{array}      % better column defs
 \usepackage{makecell}   % easy multi-line headers (optional)
-\usepackage{tabularx}
-\usepackage{array}
-\usepackage{makecell} % you already have this
 \usepackage[dvipsnames]{xcolor}
 \newcolumntype{Y}{>{\raggedright\arraybackslash}X} % flexible, left-aligned column
 


### PR DESCRIPTION
## Summary
- Deduplicate LaTeX preamble in `elsarticle-template-num.tex` by keeping a single `\usepackage` line for `amsmath`, `tabularx`, `array`, and `makecell`.

## Testing
- `pdflatex -interaction=nonstopmode -file-line-error elsarticle-template-num.tex` *(fails: File `algorithm2e.sty` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd94157ef083328f1eb39dc758c245