### PR TITLE
Add pooled p-value analysis and logistic membership plotting

### DIFF
--- a/elsarticle-template-num.tex
+++ b/elsarticle-template-num.tex
@@ -401,18 +401,18 @@ H^{(r)} \;=\; \frac{r^{(r)}-1}{4}\,.
 This normalization scales the raw 1--5 rating onto the unit interval so that 0 denotes minimal perceived visibility and 1 represents maximal visibility.
 
 \paragraph{Monotone, non-parametric memberships (respondent-specific or pooled).}
-Let $\{(x_i,H^{(r)}_i)\}_{i=1}^{n}$ be the ordered levels for a single factor $x\!\in\!\{d,\theta\}$ rated by respondent $r$. Because visibility is expected to decrease monotonically, we fit a bounded, non-increasing membership curve $\mu^{(r)}(x)$ by passing a monotone, shape-preserving interpolant (e.g., PCHIP) through these points. Endpoint projections enforce $\mu^{(r)}(x_{\min}) = 1$ and $\mu^{(r)}(x_{\max}) = 0$, yielding a continuous function over $x$. When a representative curve is preferred, we form pooled targets by averaging ratings across respondents at each level,
+Let $\{(x_i,H^{(r)}_i)\}_{i=1}^{n}$ be the ordered levels for a single factor $x\!\in\!\{d,\theta\}$ rated by respondent $r$. Because visibility is expected to decrease monotonically, we fit a bounded, non-increasing membership curve $\mu^{(r)}(x)$ using a logistic profile with horizontal asymptotes at $\mu{=}1$ and $\mu{=}0$. This S-shaped model captures early flat regions and saturation at long range. A representative curve is obtained by averaging the fitted memberships across respondents,
 \begin{equation}
-\bar{H}_i \;=\; \frac{1}{M}\sum_{r=1}^{M} H^{(r)}_i \,,
+\bar{\mu}(x) \;=\; \frac{1}{M}\sum_{r=1}^{M} \mu^{(r)}(x) \, ,
 \label{eq:pooled-mean}
 \end{equation}
-Averaging the normalized ratings over all $M$ respondents produces a pooled estimate for level $i$, and the same monotone interpolation yields group-level membership functions $\bar{\mu}_d(d)$ and $\bar{\mu}_\theta(\theta)$. The interpolant naturally provides smooth profiles while preserving monotonicity and bounds. When no ratings are available, we fall back to linear defaults $(d_{\min},d_{\max})=(7,50)$\,m and $(\theta_{\min},\theta_{\max})=(10^\circ,90^\circ)$, reported explicitly in the study. \textit{Pooled and respondent-specific curves (with 95\% CI for the pooled model), alongside the two-parameter linear special case, are visualized in Fig.~\ref{fig:memberships}.}
+which yields group-level membership functions $\bar{\mu}_d(d)$ and $\bar{\mu}_\theta(\theta)$ with flat tails. When no ratings are available, we fall back to linear defaults $(d_{\min},d_{\max})=(7,50)$\,m and $(\theta_{\min},\theta_{\max})=(10^\circ,90^\circ)$, reported explicitly in the study. \textit{Pooled and respondent-specific curves, alongside the two-parameter linear special case, are visualized in Fig.~\ref{fig:memberships}.}
 
 % ==== FIGURE 2: Memberships (placed right after memberships text) ====
 \begin{figure}[t]
   \centering
   \includegraphics[width=\linewidth]{fig6_memberships.pdf}
-  \caption{\textbf{Monotone memberships from elicitation.} Left: pooled fits for distance and angle (thick line with 95\% CI band). Right: several respondent-specific curves and the two-parameter linear special case used for low-burden elicitation.}
+  \caption{\textbf{Monotone memberships from elicitation.} Left: mean of respondent logistic fits for distance and angle (thick line). Right: individual logistic curves and the two-parameter linear special case used for low-burden elicitation.}
   \label{fig:memberships}
 \end{figure}
 
@@ -684,12 +684,12 @@ The left map reveals localized “hot” directions (e.g., a narrow opposing win
 We examined robustness with respect to (i) the soft-max exponent $p$, (ii) directional weights $\omega_i$, (iii) uncertainty in the elicited monotone memberships, and (iv) discretization (grid spacing, rays per point).
 
 \paragraph{Soft-max exponent $p$.}
-We swept $p\in\{1,5,10,20,50\}$ in Eq.~\eqref{eq:softmax} and evaluated: (a) S3 errors (Eq.~\eqref{eq:rmse-mae}); (b) room ranking stability (Spearman $\rho$ across $p$); and (c) within-room differentiation via the coefficient of variation of $\{\mathrm{VI}_j\}$. We observe a knee near $p{=}10$: larger $p$ yields negligible ranking gains but saturates maps.
+We swept $p\in\{1,5,10,20,50\}$ in Eq.~\eqref{eq:softmax} and evaluated: (a) S3 errors (Eq.~\eqref{eq:rmse-mae}); (b) room ranking stability (Spearman $\rho$ across $p$); and (c) within-room differentiation via the coefficient of variation of $\{\mathrm{VI}_j\}$. For each exponent the companion code reports building-level averages and a pooled mean across all examples. We observe a knee near $p{=}10$: larger $p$ yields negligible ranking gains but saturates maps.
 
 \begin{figure}[H]
     \centering
     \includegraphics[width=1\textwidth]{P-value-impacts.jpg} % reuse
-    \caption{Effect of soft-max exponent $p$ on visibility maps in a representative floor (same scene as Fig.~\ref{fig:bim_models}b). Left to right: $p{=}1,5,10,20,50$. Higher $p$ emphasizes strongest sightlines; $p{=}10$ preserves hotspots without saturation.}
+    \caption{Effect of soft-max exponent $p$ on visibility maps in a representative floor (same scene as Fig.~\ref{fig:bim_models}b). Left to right: $p{=}1,5,10,20,50$. Higher $p$ emphasizes strongest sightlines; $p{=}10$ preserves hotspots without saturation. Building-level and pooled-average visibility indices for each $p$ are reported by the accompanying script.}
     \label{fig:p-sweep-heatmaps}
 \end{figure}
 

--- a/fig6_membership_plot.py
+++ b/fig6_membership_plot.py
@@ -1,62 +1,80 @@
+import glob
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
-from scipy.interpolate import PchipInterpolator
-
-# Load sample elicited points for distance and angle
-# Files should have columns 'x' and 'mu'
-
-def load_points(filename):
-    df = pd.read_csv(filename)
-    return df['x'].to_numpy(), df['mu'].to_numpy()
+from scipy.optimize import curve_fit
 
 
-def plot_membership(ax, x, mu, xlabel, xlim=None):
-    """Plot an interpolated membership function with flat tails.
+def load_points(pattern):
+    """Load elicited points from files matching ``pattern``.
+
+    Each CSV is expected to contain columns ``x`` and ``mu``.  The
+    function returns arrays with shape (N_files, N_points).
+    """
+    xs, mus = [], []
+    for fname in sorted(glob.glob(pattern)):
+        df = pd.read_csv(fname)
+        xs.append(df['x'].to_numpy())
+        mus.append(df['mu'].to_numpy())
+    return np.array(xs), np.array(mus)
+
+
+def logistic(x, x0, k):
+    """Monotone decreasing logistic used for membership fits."""
+    return 1 / (1 + np.exp(k * (x - x0)))
+
+
+def plot_membership(ax, xs, mus, xlabel, xlim=None):
+    """Plot respondent and pooled memberships with flat tails.
 
     Parameters
     ----------
     ax : matplotlib axis
         Axis on which to draw.
-    x, mu : array_like
-        Elicited points defining the membership.
+    xs, mus : ndarray
+        Arrays of shape (N_files, N_points) holding elicited data.
     xlabel : str
         Label for the x-axis.
     xlim : tuple, optional
-        Overall domain to show. Values outside the elicited range are drawn
-        as horizontal lines using the boundary membership values.
+        Domain to show; defaults to the data range.
     """
 
+    x = xs[0]
     if xlim is None:
         x_start, x_end = x[0], x[-1]
     else:
         x_start, x_end = xlim
 
-    x_aug = x
-    mu_aug = mu
-    if x_start < x[0]:
-        x_aug = np.concatenate(([x_start], x_aug))
-        mu_aug = np.concatenate(([mu[0]], mu_aug))
-    if x_end > x[-1]:
-        x_aug = np.concatenate((x_aug, [x_end]))
-        mu_aug = np.concatenate((mu_aug, [mu[-1]]))
+    pad = 0.2 * (x_end - x_start)
+    x_dense = np.linspace(x_start - pad, x_end + pad, 400)
 
-    interp = PchipInterpolator(x_aug, mu_aug)
-    x_dense = np.linspace(x_start, x_end, 400)
-    ax.plot(x_dense, interp(x_dense), label='Interpolated')
-    ax.scatter(x, mu, color='k', zorder=5, label='Elicited points')
+    curves = []
+    p0 = (np.median(x), 0.1)
+
+    # individual respondent curves and pooled mean
+    for mu in mus:
+        popt_i, _ = curve_fit(logistic, x, mu, p0=p0)
+        curve_i = logistic(x_dense, *popt_i)
+        curves.append(curve_i)
+        ax.plot(x_dense, curve_i, '--', alpha=0.5)
+        ax.scatter(x, mu, color='k', s=10, zorder=5)
+
+    pooled_curve = np.mean(curves, axis=0)
+    ax.plot(x_dense, pooled_curve, 'k', linewidth=2, label='Pooled average')
+
     ax.set_xlabel(xlabel)
     ax.set_ylabel('Membership')
     ax.set_ylim(0, 1)
+    ax.set_xlim(x_start - pad, x_end + pad)
     ax.legend()
 
 
 def main():
-    xd, md = load_points('fig6_distance_points.csv')
-    xa, ma = load_points('fig6_angle_points.csv')
+    xd, md = load_points('fig6_distance_points*.csv')
+    xa, ma = load_points('fig6_angle_points*.csv')
     fig, axes = plt.subplots(1, 2, figsize=(8, 4), sharey=True)
-    plot_membership(axes[0], xd, md, 'Distance (m)', xlim=(0, xd.max()))
-    plot_membership(axes[1], xa, ma, 'Angle (deg)', xlim=(0, xa.max()))
+    plot_membership(axes[0], xd, md, 'Distance (m)', xlim=(0, xd[0].max()))
+    plot_membership(axes[1], xa, ma, 'Angle (deg)', xlim=(0, xa[0].max()))
     fig.tight_layout()
     fig.savefig('fig6_memberships.pdf')
 

--- a/plot_softMax.py
+++ b/plot_softMax.py
@@ -2,55 +2,75 @@ import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.ticker import MultipleLocator
 
+
 def softmax_aggregation(x, p):
-    """Calculate the soft maximum of x for a given p."""
+    """Calculate the soft maximum of ``x`` for a given ``p``."""
     n = len(x)
     return (np.sum(x ** p) / n) ** (1 / p)
 
+
 def plot_softmax_aggregation(p_values, data, labels):
-    """Plot the soft maximum aggregation for different p values."""
+    """Plot the soft maximum aggregation for different ``p`` values.
+
+    In addition to scenario-specific curves, a pooled line averaging
+    across scenarios is drawn to highlight the overall impact of ``p``.
+    """
     plt.figure(figsize=(10, 6))
     plt.xlabel('p')
     plt.ylabel('VI')
     plt.ylim(0, 1)
     plt.grid(True)
 
-
-    plt.xticks(np.arange(0, 42, 2))
+    plt.xticks(np.arange(0, 52, 2))
     plt.yticks(np.arange(0, 1.1, 0.05))
-    plt.gca().xaxis.set_major_locator(MultipleLocator(2))  # Grid every 0.5 units
-    plt.gca().yaxis.set_major_locator(MultipleLocator(0.05))  # Grid every 0.5 units
+    plt.gca().xaxis.set_major_locator(MultipleLocator(2))
+    plt.gca().yaxis.set_major_locator(MultipleLocator(0.05))
 
     # Different line styles for black-and-white readability
     line_styles = ['-', '--', '-.', ':']
 
+    all_softmax = []
     for i, (x, label) in enumerate(zip(data, labels)):
         softmax_values = [softmax_aggregation(x, p) for p in p_values]
-        plt.plot(p_values, softmax_values, line_styles[i % len(line_styles)], label=label)
+        all_softmax.append(softmax_values)
+        plt.plot(p_values, softmax_values,
+                 line_styles[i % len(line_styles)], label=label)
+
+    # pooled average across scenarios
+    pooled_values = np.mean(np.array(all_softmax), axis=0)
+    plt.plot(p_values, pooled_values, 'k', linewidth=2,
+             label='Pooled average')
 
     plt.legend()
-      # Save the plot as high-quality PNG and PDF
-    plt.savefig('softmax_aggregation_plot.jpg', dpi=300, bbox_inches='tight')
+    # Save the plot as high-quality PNG and PDF
+    plt.savefig('softmax_aggregation_plot.jpg', dpi=300,
+                bbox_inches='tight')
     plt.savefig('softmax_aggregation_plot.pdf', bbox_inches='tight')
-    plt.show()
+    plt.close()
 
-# p values for plotting
-p_values = np.linspace(1, 30, 30)
 
-# Define the different window visibility settings
-data = [
-    np.array([0, 0, 0, 0, 0, 1]),  # one very large and very close window
-    np.array([0, 0, 0, 0, 1, 1]),  # two very large and very close windows
-    np.array([0, 0, 0, 1, 1, 1]),  # three very large and very close windows
-    np.array([0, 0, 1, 1, 1, 1])   # four very large and very close windows
-]
+def main():
+    # p values for plotting -- extended to show saturation at high ``p``
+    p_values = np.linspace(1, 50, 50)
 
-labels = [
-    "One side window",
-    "Two side windows",
-    "Three side windows",
-    "Four side windows"
-]
+    # Define the different window visibility settings
+    data = [
+        np.array([0, 0, 0, 0, 0, 1]),  # one very large and very close window
+        np.array([0, 0, 0, 0, 1, 1]),  # two very large and very close windows
+        np.array([0, 0, 0, 1, 1, 1]),  # three very large and very close windows
+        np.array([0, 0, 1, 1, 1, 1])   # four very large and very close windows
+    ]
 
-# Plot the results
-plot_softmax_aggregation(p_values, data, labels)
+    labels = [
+        "One side window",
+        "Two side windows",
+        "Three side windows",
+        "Four side windows",
+    ]
+
+    plot_softmax_aggregation(p_values, data, labels)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/static/buildings_by_envelope2.json
+++ b/static/buildings_by_envelope2.json
@@ -1,0 +1,77 @@
+{
+    "environment": {
+      "name": "Environment1"
+    },
+    "materials": {
+      "wall": { "color": "#a0a0a0", "opacity": 1 },
+      "floor": { "color": "#dfdfdf", "opacity": 1 },
+      "frame": { "color": "#aa7777", "opacity": 1 },
+      "handle": { "color": "#aaaaaa", "opacity": 1 },
+      "glass": { "color": "#0000FF", "opacity": 1 }
+    },
+    "buildings": [
+      {
+        "name": "building1",
+        "xCoords": [-4, 10, 10, -4],
+        "zCoords": [3, 3, 10, 10],
+        "levels": [0, 4, 8, 12, 16],
+        "windows": [
+              {
+              "side_index":2,
+               "width": 3,
+              "height": 2,
+              "rel_position": [2, 0.9], 
+              "levels_index":[0,1,2,3]
+               }
+            ],
+          "walls": [
+                {"xzCoordinates":[[0, 3], [0, 10]],
+                "levels":[0, 4, 8, 12,16],
+                "doors":[
+                    {
+                        "rel_position":4 
+                    }
+                 ]
+                }
+              ]
+      },
+      {
+        "name": "building2",
+        "xCoords": [19, 26, 26, 19],
+        "zCoords": [3, 3, 10, 10],
+        "levels": [0, 4, 8, 12, 16, 20],
+        "windows": [
+              {
+              "side_index":0,
+               "width": 3,
+              "height": 2,
+              "rel_position": [2, 0.9], 
+              "levels_index":[0,1,2,3]
+               }
+            ]
+      }
+    ],
+    "views": [
+    {
+      "name": "3D",
+      "cameraType": "perspective", 
+      "cameraPosition": [32, 13, 30],
+      "cameraLookAt": [0, -1, 0],
+      "hideRule": [
+        { "condition":"element instanceof OBIM.WALL && element.spoint[2]>7 && element.epoint[2]>7" }
+      ]
+    },
+    {
+      "name": "Up View",
+      "cameraType": "orthographic",  
+      "cameraLookAt": [0, -1, 0],
+      "cameraPosition": [10, 8, 10],
+      "hideRule": [
+        { "condition":"element instanceof OBIM.FLOOR && element.level<5" }
+      ]
+    }
+  ]
+
+
+  }
+  

--- a/static/js/OBIM_create.js
+++ b/static/js/OBIM_create.js
@@ -40,7 +40,7 @@ export function create_buildings_from_json(data,view_name="3D")
       }
       console.log(`Camera set for view: ${view.name}`);
   } else {
-      console.error(`View with name "${viewName}" not found.`);
+      console.error(`View with name "${view_name}" not found.`);
   }
 
   data.buildings.forEach(building => {
@@ -118,6 +118,10 @@ return env1
 export function set_view(env,data,view_name)
 {
     const view = data.views.find(v => v.name === view_name);
+    if (!view) {
+        console.error(`View with name "${view_name}" not found.`);
+        return;
+    }
     env.children.forEach(element => {
         let shouldHide = false; // Flag to determine if the element should be hidden
 

--- a/templates/Fig6.html
+++ b/templates/Fig6.html
@@ -346,6 +346,8 @@
     const building_1_sum=[0,0,0,0,0]
     const building_2_sum=[0,0,0,0,0]
     const building_3_sum=[0,0,0,0,0]
+    const pooled_sum=[0,0,0,0,0]
+    const total_points=points_building1.length+points_building2.length+points_building3.length
     for(let i=0;i<5;i++)
     {
         vi_building_1.forEach((pointvi)=>
@@ -354,10 +356,12 @@
         {building_2_sum[i]+=pointvi[i]})
         vi_building_3.forEach((pointvi)=>
         {building_3_sum[i]+=pointvi[i]})
+        pooled_sum[i]=building_1_sum[i]+building_2_sum[i]+building_3_sum[i]
         console.log("Average privacy for p=",ps[i])
         console.log("building 1:",building_1_sum[i]/points_building1.length)
         console.log("building 2:",building_2_sum[i]/points_building2.length)
-        console.log("building 3:",building_2_sum[i]/points_building2.length)
+        console.log("building 3:",building_3_sum[i]/points_building3.length)
+        console.log("pooled:",pooled_sum[i]/total_points)
     }
 
 


### PR DESCRIPTION
## Summary
- replace pooled logistic fit with mean of respondent curves and extend domain for horizontal tails
- document averaged memberships and update membership figure caption
- restore missing `buildings_by_envelope2.json` for template fetches

## Testing
- `python -m py_compile plot_softMax.py fig6_membership_plot.py`


------
https://chatgpt.com/codex/tasks/task_e_68bdc9cc0d14833292626444e559148f