### PR TITLE
feat: add PostgreSQL connection

### DIFF
--- a/OBIM.py
+++ b/OBIM.py
@@ -1,9 +1,31 @@
 import mimetypes
-mimetypes.add_type('application/javascript', '.js')
-mimetypes.add_type('text/css', '.css')
-from flask import Flask, render_template
+import os
+
+import psycopg2
+from flask import Flask, g, render_template
 
 app = Flask(__name__)
+
+mimetypes.add_type('application/javascript', '.js')
+mimetypes.add_type('text/css', '.css')
+
+
+DATABASE_URL = os.environ.get("DATABASE_URL")
+
+
+def get_db_connection():
+    if DATABASE_URL is None:
+        raise RuntimeError("DATABASE_URL is not set")
+    if "db_conn" not in g:
+        g.db_conn = psycopg2.connect(DATABASE_URL)
+    return g.db_conn
+
+
+@app.teardown_appcontext
+def close_db_connection(exception=None):
+    conn = g.pop("db_conn", None)
+    if conn is not None:
+        conn.close()
 
 @app.route('/')
 def index():
@@ -48,6 +70,16 @@ def Distance_impact():
 @app.route('/Angle_impact')
 def Angle_impact():
     return render_template('Angle_impact.html')
+
+
+@app.route('/db_version')
+def db_version():
+    conn = get_db_connection()
+    cur = conn.cursor()
+    cur.execute("SELECT version();")
+    version = cur.fetchone()[0]
+    cur.close()
+    return f"PostgreSQL version: {version}"
 
 
 @app.after_request

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+psycopg2-binary
+


### PR DESCRIPTION
## Summary
- connect Flask app to PostgreSQL using `psycopg2`
- expose `/db_version` route to show server version
- declare Flask and psycopg2-binary dependencies

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile OBIM.py`


------
https://chatgpt.com/codex/tasks/task_e_68bde1f31c5483328da0d6f79476c86b