### PR TITLE
refactor: externalize inline index script

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -1,0 +1,10 @@
+import * as OBIMcreate from './OBIM_create.js';
+import * as THREE from 'https://threejsfundamentals.org/threejs/resources/threejs/r122/build/three.module.js';
+
+const response = await fetch('./static/buildings_by_envelope.json');
+const data = await response.json();
+const renderer = new THREE.WebGLRenderer();
+renderer.setSize(window.innerWidth, window.innerHeight);
+document.body.appendChild(renderer.domElement);
+
+const env1 = OBIMcreate.create_buildings_from_json(data, renderer, "3D");

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,20 +10,6 @@
 <body>
     
     <header></header>
-    <script type="module">
-        // Basic Three.js scene setup
-        // import * as THREE from 'https://threejsfundamentals.org/threejs/resources/threejs/r122/build/three.module.js';
-        // import * as OBIM from './static/js/main.js'
-        // import * as families from './static/js/families.js'
-        import * as OBIMcreate from './static/js/OBIM_create.js'
-        const response = await fetch('./static/buildings_by_envelope.json');
-        import * as THREE from 'https://threejsfundamentals.org/threejs/resources/threejs/r122/build/three.module.js';
-        const data = await response.json();
-        const renderer = new THREE.WebGLRenderer();
-        renderer.setSize(window.innerWidth, window.innerHeight);
-        document.body.appendChild(renderer.domElement);
-
-        const env1=OBIMcreate.create_buildings_from_json(data,renderer,"3D")
-    </script>
+    <script type="module" src="{{ url_for('static', filename='js/index.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- move embedded Three.js demo logic from `templates/index.html` into module `static/js/index.js`
- reference external module in `index.html` to satisfy strict CSP requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68be573f7a008332a7dd276d1f775ab6