### PR TITLE
Fix JSON path in index.js

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -1,10 +1,22 @@
 import * as OBIMcreate from './OBIM_create.js';
 import * as THREE from './three.module.js';
 
-const response = await fetch('../buildings_by_envelope.json');
-const data = await response.json();
-const renderer = new THREE.WebGLRenderer();
-renderer.setSize(window.innerWidth, window.innerHeight, false);
-document.body.appendChild(renderer.domElement);
+async function init() {
+    try {
+        const response = await fetch('/static/buildings_by_envelope.json');
+        if (!response.ok) {
+            throw new Error(`HTTP ${response.status} ${response.statusText}`);
+        }
+        const data = await response.json();
 
-const env1 = OBIMcreate.create_buildings_from_json(data, renderer, "3D");
+        const renderer = new THREE.WebGLRenderer();
+        renderer.setSize(window.innerWidth, window.innerHeight, false);
+        document.body.appendChild(renderer.domElement);
+
+        OBIMcreate.create_buildings_from_json(data, renderer, "3D");
+    } catch (err) {
+        console.error('Failed to load buildings data:', err);
+    }
+}
+
+init();


### PR DESCRIPTION
## Summary
- fix incorrect path to buildings_by_envelope.json by using absolute static path
- add basic error handling when fetching building data

## Testing
- `python -m py_compile OBIM.py`
- `node --check static/js/index.js`


------
https://chatgpt.com/codex/tasks/task_e_68be618010608332aa84fd54001696da