### PR TITLE
Fix JSON path and renderer reference

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -1,10 +1,22 @@
 import * as OBIMcreate from './OBIM_create.js';
 import * as THREE from './three.module.js';
 
-const response = await fetch('../buildings_by_envelope.json');
-const data = await response.json();
-const renderer = new THREE.WebGLRenderer();
-renderer.setSize(window.innerWidth, window.innerHeight, false);
-document.body.appendChild(renderer.domElement);
+async function init() {
+    try {
+        const response = await fetch('/static/buildings_by_envelope.json');
+        if (!response.ok) {
+            throw new Error(`HTTP ${response.status} ${response.statusText}`);
+        }
+        const data = await response.json();
 
-const env1 = OBIMcreate.create_buildings_from_json(data, renderer, "3D");
+        const renderer = new THREE.WebGLRenderer();
+        renderer.setSize(window.innerWidth, window.innerHeight, false);
+        document.body.appendChild(renderer.domElement);
+
+        OBIMcreate.create_buildings_from_json(data, renderer, "3D");
+    } catch (err) {
+        console.error('Failed to load buildings data:', err);
+    }
+}
+
+init();

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -8,18 +8,18 @@ import { PointerLockControls } from './PointerLockControls.js';
 //*********************************************/
 export class BuiltEnvironment extends THREE.Scene
 {
-  constructor(name,renderer)
+  constructor(name, renderer)
   {
     super()
-    this.name=name;
-    this.BuiltObjects=[];
+    this.name = name;
+    this.BuiltObjects = [];
     this.background = new THREE.Color( 0xffffff );
     this.camera = new THREE.PerspectiveCamera(75, window.innerWidth/window.innerHeight, 0.1, 1000);
     this.camera.position.setZ(30);
     this.camera.position.setY(10);
     this.camera.position.setX(10);
-    this.renderer=renderer;
-    renderer.render(this,this.camera);
+    this.renderer = renderer;
+    this.renderer.render(this, this.camera);
 
     const amblight=new THREE.AmbientLight(0xffffff,1);
     this.add(amblight);
@@ -48,7 +48,7 @@ export class BuiltEnvironment extends THREE.Scene
  
     // Bind the animate function to the correct context
     // Initialize controls
-    this.orbitControls = new OrbitControls(this.camera, renderer.domElement);
+    this.orbitControls = new OrbitControls(this.camera, this.renderer.domElement);
     this.pointerLockControls = new PointerLockControls(this.camera, document.body);
     let isPointerLocked=false;
     // Add an event listener for Pointer Lock
@@ -108,7 +108,7 @@ export class BuiltEnvironment extends THREE.Scene
           this.orbitControls.update();
       }
   
-      renderer.render(this, this.camera);
+      this.renderer.render(this, this.camera);
   }
     saveView()
     {


### PR DESCRIPTION
## Summary
- fix incorrect path to buildings_by_envelope.json by using absolute static path
- add basic error handling when fetching building data
- correct BuiltEnvironment to use instance renderer for controls and animation

## Testing
- `python -m py_compile OBIM.py`
- `node --check static/js/index.js`
- `node --check static/js/main.js`


------
https://chatgpt.com/codex/tasks/task_e_68be618010608332aa84fd54001696da